### PR TITLE
Handle file protocol on initialisation

### DIFF
--- a/src/BrowserProtocol.js
+++ b/src/BrowserProtocol.js
@@ -13,7 +13,7 @@ export default class BrowserProtocol {
   }
 
   init() {
-    const { pathname, search, hash } = window.location;
+    const { protocol, pathname, search, hash } = window.location;
 
     const { key, index = 0, state } = window.history.state || {};
     const delta = this._index != null ? index - this._index : 0;
@@ -21,7 +21,7 @@ export default class BrowserProtocol {
 
     return {
       action: 'POP',
-      pathname,
+      pathname: protocol === 'file:' ? '/' : pathname,
       search,
       hash,
       key,


### PR DESCRIPTION
When trying to bundle my found-relay (modern) react app into an electron distributable, I realised that the routing wouldn't work on first load as the pathname would be something like `/home/jtfell/project/dist/index.html` when I really wanted to start at `/`.

This change seems to have fixed that, with all subsequent internal links working as relative paths. I'm not at all sure if this is the best approach to handle all the edge-cases surrounding the file protocol but it works for me.

One issue I ran into is that making the change here causes it not to be triggered when the page is refreshed. Do you have any ideas on a better place to slot this in @taion? Even if you don't want to merge this it would be great to get your thoughts.