### PR TITLE
Add tests for BrowserProtocol

### DIFF
--- a/test/BrowserProcotol.test.js
+++ b/test/BrowserProcotol.test.js
@@ -1,0 +1,173 @@
+import BrowserProtocol from '../src/BrowserProtocol';
+
+import { timeout } from './helpers';
+
+describe('BrowserProtocol', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, null, '/');
+  });
+
+  it('should parse the initial location', () => {
+    window.history.replaceState(null, null, '/foo?bar=baz#qux');
+    const protocol = new BrowserProtocol();
+
+    expect(protocol.init()).to.eql({
+      action: 'POP',
+      pathname: '/foo',
+      search: '?bar=baz',
+      hash: '#qux',
+      key: undefined,
+      index: 0,
+      delta: 0,
+      state: undefined,
+    });
+  });
+
+  it('should support basic navigation', async () => {
+    window.history.replaceState(null, null, '/foo');
+    const protocol = new BrowserProtocol();
+
+    const listener = sinon.spy();
+    protocol.subscribe(listener);
+
+    const barLocation = protocol.transition({
+      action: 'PUSH',
+      pathname: '/bar',
+      search: '?search',
+      hash: '#hash',
+      state: { the: 'state' },
+    });
+
+    expect(window.location).to.include({
+      pathname: '/bar',
+      search: '?search',
+      hash: '#hash',
+    });
+    expect(barLocation).to.deep.include({
+      action: 'PUSH',
+      pathname: '/bar',
+      search: '?search',
+      hash: '#hash',
+      index: 1,
+      delta: 1,
+      state: { the: 'state' },
+    });
+    expect(barLocation.key).not.to.be.empty();
+
+    expect(
+      protocol.transition({
+        action: 'PUSH',
+        pathname: '/baz',
+        search: '',
+        hash: '',
+      }),
+    ).to.include({
+      action: 'PUSH',
+      pathname: '/baz',
+      index: 2,
+      delta: 1,
+    });
+
+    expect(window.location.pathname).to.equal('/baz');
+
+    expect(
+      protocol.transition({
+        action: 'REPLACE',
+        pathname: '/qux',
+        search: '',
+        hash: '',
+      }),
+    ).to.include({
+      action: 'REPLACE',
+      pathname: '/qux',
+      index: 2,
+      delta: 0,
+    });
+
+    expect(window.location.pathname).to.equal('/qux');
+    expect(listener).not.to.have.been.called();
+
+    protocol.go(-1);
+    await timeout(20);
+
+    expect(window.location).to.include({
+      pathname: '/bar',
+      search: '?search',
+      hash: '#hash',
+    });
+    expect(listener).to.have.been.calledOnce();
+    expect(listener.firstCall.args[0]).to.deep.include({
+      action: 'POP',
+      pathname: '/bar',
+      search: '?search',
+      hash: '#hash',
+      key: barLocation.key,
+      index: 1,
+      delta: -1,
+      state: { the: 'state' },
+    });
+    listener.reset();
+
+    window.history.back();
+    await timeout(20);
+
+    expect(window.location.pathname).to.equal('/foo');
+    expect(listener).to.have.been.calledOnce();
+    expect(listener.firstCall.args[0]).to.deep.include({
+      action: 'POP',
+      pathname: '/foo',
+      index: 0,
+      delta: -1,
+      state: undefined,
+    });
+    listener.reset();
+  });
+
+  it('should support subscribing and unsubscribing', async () => {
+    const protocol = new BrowserProtocol();
+    protocol.transition({
+      action: 'PUSH',
+      pathname: '/bar',
+      search: '',
+      hash: '',
+    });
+    protocol.transition({
+      action: 'PUSH',
+      pathname: '/baz',
+      search: '',
+      hash: '',
+    });
+
+    const listener = sinon.spy();
+    const unsubscribe = protocol.subscribe(listener);
+
+    protocol.go(-1);
+    await timeout(20);
+
+    expect(listener).to.have.been.calledOnce();
+    expect(listener.firstCall.args[0]).to.include({
+      action: 'POP',
+      pathname: '/bar',
+    });
+    listener.reset();
+
+    unsubscribe();
+
+    protocol.go(-1);
+    await timeout(20);
+
+    expect(listener).not.to.have.been.called();
+  });
+
+  it('should support createHref', () => {
+    const protocol = new BrowserProtocol();
+
+    expect(
+      protocol.createHref({
+        pathname: '/foo',
+        search: '?bar=baz',
+        hash: '#qux',
+      }),
+    ).to.equal('/foo?bar=baz#qux');
+  });
+});

--- a/test/MemoryProcotol.test.js
+++ b/test/MemoryProcotol.test.js
@@ -1,7 +1,7 @@
 import MemoryProtocol from '../src/MemoryProtocol';
 
-describe.only('MemoryProtocol', () => {
-  it('should parse the initial loocation', () => {
+describe('MemoryProtocol', () => {
+  it('should parse the initial location', () => {
     const protocol = new MemoryProtocol('/foo?bar=baz#qux');
 
     expect(protocol.init()).to.eql({
@@ -25,6 +25,7 @@ describe.only('MemoryProtocol', () => {
       pathname: '/bar',
       state: { the: 'state' },
     });
+
     expect(barLocation).to.deep.include({
       action: 'PUSH',
       pathname: '/bar',

--- a/test/ServerProtocol.test.js
+++ b/test/ServerProtocol.test.js
@@ -1,8 +1,9 @@
 import ServerProtocol from '../src/ServerProtocol';
 
 describe('ServerProtocol', () => {
-  it('should create initial location when init is called', () => {
+  it('should parse the initial location', () => {
     const protocol = new ServerProtocol('/foo?bar=baz#qux');
+
     expect(protocol.init()).to.eql({
       action: 'POP',
       pathname: '/foo',
@@ -11,14 +12,15 @@ describe('ServerProtocol', () => {
     });
   });
 
-  it('should not throw when unsubscribe is called', () => {
+  it('should have dummy support for subscriptions', () => {
     const protocol = new ServerProtocol('/foo?bar=baz#qux');
     const unsubscribe = protocol.subscribe();
     expect(unsubscribe).to.not.throw();
   });
 
-  it('should create href when createHref is called with location', () => {
+  it('should support createHref', () => {
     const protocol = new ServerProtocol('/foo?bar=baz#qux');
+
     expect(
       protocol.createHref({
         pathname: '/foo',

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,3 +25,9 @@ export function invokeMakeLocation(middleware, location) {
     payload: location,
   }).payload;
 }
+
+export function timeout(delay) {
+  return new Promise(resolve => {
+    setTimeout(resolve, delay);
+  });
+}


### PR DESCRIPTION
This is a cut-down version of the MemoryProtocol test suite. I dropped the tests for things like bounds-checking that we don't need to assert ourselves.